### PR TITLE
Set default icon theme to "breeze". Add oxygen-icons package.

### DIFF
--- a/airootfs/etc/skel/.config/kdeglobals
+++ b/airootfs/etc/skel/.config/kdeglobals
@@ -1,0 +1,2 @@
+[Icons]
+Theme=breeze

--- a/packages.both
+++ b/packages.both
@@ -80,3 +80,4 @@ plasma-camera-git
 plasma-settings-git
 kwinwrapper-git
 konsole
+oxygen-icons


### PR DESCRIPTION
Right now most icons are not shown (at least for me) and "Icon theme oxygen wasn't found" message appears at logs. Also, icon theme is set in ~/.config/kdeglobals but only after start of shell and looks like it doesn't use that new value.

That patch sets default icon theme to "breeze" so plasma-mobile uses it even at first start. Also, oxygen-icons package was added because Breeze icon theme hasn't icon for camera application (and shell tries to use oxygen theme as fallback).
